### PR TITLE
Add VS Code launch configuration for tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,16 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Current File",
+            "name": "Debug pytest",
             "type": "python",
             "request": "launch",
-            "program": "${file}",
-            "console": "integratedTerminal"
+            "module": "pytest",
+            "args": ["tests/test_main.py"],
+            "console": "integratedTerminal",
+            "justMyCode": true
         },
         {
-            "name": "Python: Main",
+            "name": "Debug main",
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/src/main.py",


### PR DESCRIPTION
## Summary
- add VS Code launch configuration for running pytest and the main script

## Testing
- `python -m pytest tests/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1571ad7d88323ae5620c344c445a6