### PR TITLE
Improve camera enumeration for CZUR devices

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the import path so ``src`` can be imported.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+import importlib
+import sys
+
+
+def setup_fake_cv2(monkeypatch):
+    """Return the scanner module loaded with a stubbed cv2 module."""
+    class FakeCapture:
+        def __init__(self, index):
+            self.index = index
+
+        def isOpened(self):
+            return False
+
+        def release(self):
+            pass
+
+    info1 = SimpleNamespace(id=0, name="Generic Cam")
+    info2 = SimpleNamespace(id=1, name="CZUR E012A")
+    registry = SimpleNamespace(getCameraInfoList=lambda: [info1, info2])
+    fake_cv2 = SimpleNamespace(videoio_registry=registry, VideoCapture=FakeCapture)
+    # ``scanner`` imports ``cv2``, ``numpy`` and ``pytesseract`` at module import
+    # time.  Provide lightweight stubs for these modules so the import succeeds
+    # without requiring the heavy dependencies.
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+    monkeypatch.setitem(sys.modules, "numpy", SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "pytesseract", SimpleNamespace())
+
+    import src.scanner as scanner
+    importlib.reload(scanner)
+    return scanner
+
+
+def test_list_cameras_uses_device_names(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    cams = scanner.list_cameras()
+    assert cams == [(0, "Generic Cam"), (1, "CZUR E012A")]


### PR DESCRIPTION
## Summary
- use OpenCV videoio_registry to list camera names and fallback to CAP_PROP_DEVICE_DESCRIPTION
- add tests for camera name discovery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1655864b88323b38b70d88562dccf