### PR TITLE
Fix hang when quitting after selecting camera

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -7,6 +7,7 @@ import re
 import sys
 import threading
 import queue
+import select
 from datetime import datetime
 from pathlib import Path
 
@@ -57,20 +58,14 @@ def select_camera(cameras: list[tuple[int, str]]) -> int:
         label = "(default)" if idx == default else ""
         print(f"[{idx}] {name} {label}")
     print("Press Enter within 2 seconds to select another camera index.")
-
-    q: queue.Queue[str] = queue.Queue()
-
-    def reader() -> None:
-        q.put(input())
-
-    t = threading.Thread(target=reader)
-    t.daemon = True
-    t.start()
+    print("> ", end="", flush=True)
     try:
-        choice = q.get(timeout=2).strip()
-        if choice.isdigit():
-            return int(choice)
-    except queue.Empty:
+        ready, _, _ = select.select([sys.stdin], [], [], 2)
+        if ready:
+            choice = sys.stdin.readline().strip()
+            if choice.isdigit():
+                return int(choice)
+    except Exception:  # pragma: no cover - best effort
         pass
     return default
 


### PR DESCRIPTION
## Summary
- replace threaded input in `select_camera` with `select.select` to avoid lingering stdin reader
- add non-blocking camera selection prompt

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b162ee00188323a98012256fd3bace