### PR TITLE
Add hand gesture countdown to trigger scan

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ opencv-python
 numpy
 pytesseract
 Pillow
+mediapipe

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -102,3 +102,17 @@ def test_check_tesseract_configures_path(monkeypatch):
         == "C:/pf/Tesseract-OCR/tesseract.exe"
     )
 
+
+def test_no_gesture_flag(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    called = {}
+
+    def fake_scan(*, skip_detection, gesture_enabled):
+        called["args"] = (skip_detection, gesture_enabled)
+
+    monkeypatch.setattr(scanner, "scan_document", fake_scan)
+    monkeypatch.setattr(sys, "argv", ["scanner", "--no-gesture"])
+    scanner.main()
+
+    assert called["args"] == (False, False)
+


### PR DESCRIPTION
## Summary
- allow a V-sign hand gesture to trigger document capture with a 3-2-1 countdown
- add `--no-gesture` flag to disable gesture trigger
- update requirements for mediapipe and test new flag

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1ad85d6208323bed3d0c2f98118cf