### PR TITLE
Use module syntax for scanner debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
             "name": "Debug scanner",
             "type": "python",
             "request": "launch",
-            "program": "${workspaceFolder}/src/scanner.py",
+            "module": "dev.scanner",
             "console": "integratedTerminal"
         }
     ]


### PR DESCRIPTION
## Summary
- run `dev.scanner` module when debugging scanner

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b287fb2c8323ad87d69a9e5196ca