### PR TITLE
Add optional contrast boost to captured images

### DIFF
--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -102,10 +102,16 @@ def correct_orientation(image: np.ndarray) -> np.ndarray:
     return image
 
 
+def increase_contrast(image: np.ndarray, factor: float = 1.25) -> np.ndarray:
+    """Return ``image`` with its contrast scaled by ``factor``."""
+    return cv2.convertScaleAbs(image, alpha=factor, beta=0)
+
+
 __all__ = [
     "find_document_contour",
     "order_points",
     "four_point_transform",
     "rotate_bound",
     "correct_orientation",
+    "increase_contrast",
 ]

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -18,6 +18,7 @@ from .image_utils import (
     correct_orientation,
     find_document_contour,
     four_point_transform,
+    increase_contrast,
 )
 from . import ocr_utils
 
@@ -120,7 +121,11 @@ def test_camera() -> None:
     cv2.destroyAllWindows()
 
 
-def scan_document(skip_detection: bool = False, gesture_enabled: bool = True) -> None:
+def scan_document(
+    skip_detection: bool = False,
+    gesture_enabled: bool = True,
+    boost_contrast: bool = True,
+) -> None:
     """Run the interactive document scanner."""
     start = time.perf_counter()
     print("[DEBUG] Starting scan_document")
@@ -266,6 +271,8 @@ def scan_document(skip_detection: bool = False, gesture_enabled: bool = True) ->
         corrected = warped
     else:
         corrected = correct_orientation(warped)
+    if boost_contrast:
+        corrected = increase_contrast(corrected)
     pdf_path = save_pdf(corrected)
     print(f"Saved {pdf_path}")
 
@@ -288,12 +295,19 @@ def main() -> None:
         action="store_true",
         help="disable hand gesture scan trigger",
     )
+    parser.add_argument(
+        "--no-contrast",
+        action="store_true",
+        help="disable 25% contrast boost",
+    )
     args = parser.parse_args()
     if args.test_camera:
         test_camera()
     else:
         scan_document(
-            skip_detection=args.no_detect, gesture_enabled=not args.no_gesture
+            skip_detection=args.no_detect,
+            gesture_enabled=not args.no_gesture,
+            boost_contrast=not args.no_contrast,
         )
 
 

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -1,0 +1,20 @@
+import importlib
+import types
+import sys
+import numpy as np
+
+
+def test_increase_contrast(monkeypatch):
+    def fake_convert(img, alpha, beta):
+        return np.clip(img * alpha + beta, 0, 255).astype(np.uint8)
+
+    fake_cv2 = types.SimpleNamespace(convertScaleAbs=fake_convert)
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+
+    image_utils = importlib.import_module("src.image_utils")
+    importlib.reload(image_utils)
+
+    img = np.array([[100, 200], [50, 0]], dtype=np.uint8)
+    result = image_utils.increase_contrast(img)
+    expected = np.clip(img * 1.25, 0, 255).astype(np.uint8)
+    assert np.array_equal(result, expected)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -107,12 +107,26 @@ def test_no_gesture_flag(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
     called = {}
 
-    def fake_scan(*, skip_detection, gesture_enabled):
-        called["args"] = (skip_detection, gesture_enabled)
+    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast):
+        called["args"] = (skip_detection, gesture_enabled, boost_contrast)
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-gesture"])
     scanner.main()
 
-    assert called["args"] == (False, False)
+    assert called["args"] == (False, False, True)
+
+
+def test_no_contrast_flag(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    called = {}
+
+    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast):
+        called["args"] = (skip_detection, gesture_enabled, boost_contrast)
+
+    monkeypatch.setattr(scanner, "scan_document", fake_scan)
+    monkeypatch.setattr(sys, "argv", ["scanner", "--no-contrast"])
+    scanner.main()
+
+    assert called["args"] == (False, True, False)
 


### PR DESCRIPTION
## Summary
- Enhance captured images with a 25% contrast boost by default
- Allow disabling contrast enhancement via `--no-contrast`
- Test new CLI flag and contrast helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c0bf7c608323b7d997c22dddbf72