### PR TITLE
Open scanned PDF with default viewer

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import os
 import queue
+import subprocess
 import sys
 import threading
 import time
@@ -75,6 +77,19 @@ def save_pdf(image: np.ndarray):  # pragma: no cover - thin wrapper
     ocr_utils.Path = Path
     ocr_utils.pytesseract = pytesseract
     return ocr_utils.save_pdf(image)
+
+
+def open_pdf(path: Path) -> None:  # pragma: no cover - OS-specific side effect
+    """Open ``path`` using the platform's default PDF viewer."""
+    try:
+        if sys.platform.startswith("win"):
+            os.startfile(str(path))  # type: ignore[attr-defined]
+        elif sys.platform.startswith("darwin"):
+            subprocess.run(["open", str(path)], check=False)
+        else:
+            subprocess.run(["xdg-open", str(path)], check=False)
+    except Exception as exc:
+        print(f"Unable to open PDF {path}: {exc}")
 
 
 def test_camera() -> None:
@@ -268,6 +283,7 @@ def scan_document(skip_detection: bool = False, gesture_enabled: bool = True) ->
         corrected = correct_orientation(warped)
     pdf_path = save_pdf(corrected)
     print(f"Saved {pdf_path}")
+    open_pdf(pdf_path)
 
 
 def main() -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 import importlib
 import sys
+from pathlib import Path
 import pytest
 
 
@@ -115,4 +116,32 @@ def test_no_gesture_flag(monkeypatch):
     scanner.main()
 
     assert called["args"] == (False, False)
+
+
+def test_open_pdf_linux(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    opened = {}
+
+    def fake_run(cmd, check):
+        opened["cmd"] = cmd
+
+    monkeypatch.setattr(scanner.subprocess, "run", fake_run)
+    monkeypatch.setattr(scanner.sys, "platform", "linux")
+    scanner.open_pdf(Path("doc.pdf"))
+
+    assert opened["cmd"] == ["xdg-open", "doc.pdf"]
+
+
+def test_open_pdf_windows(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    opened = {}
+
+    def fake_startfile(path):
+        opened["path"] = path
+
+    monkeypatch.setattr(scanner.os, "startfile", fake_startfile, raising=False)
+    monkeypatch.setattr(scanner.sys, "platform", "win32")
+    scanner.open_pdf(Path("doc.pdf"))
+
+    assert opened["path"] == "doc.pdf"
 


### PR DESCRIPTION
## Summary
- open the generated PDF with the system's default viewer after scanning
- add cross-platform helper function and tests for Linux and Windows cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c0f35bc88323ba8d7b2c3a33abdb