### PR TITLE
Improve camera resolution and PDF quality

### DIFF
--- a/src/ocr_utils.py
+++ b/src/ocr_utils.py
@@ -38,7 +38,10 @@ def save_pdf(image) -> Path:
     check_tesseract_installation()
     pil_img = Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
     pil_img.info["dpi"] = (300, 300)
-    pdf_bytes = pytesseract.image_to_pdf_or_hocr(pil_img, extension="pdf")
+    config = "--dpi 300 -c jpeg_quality=100"
+    pdf_bytes = pytesseract.image_to_pdf_or_hocr(
+        pil_img, extension="pdf", config=config
+    )
     filename = datetime.now().strftime("%Y%m%d%H%M%S") + ".pdf"
     path = Path(filename)
     path.write_bytes(pdf_bytes)

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -87,8 +87,8 @@ def test_camera() -> None:
     _debug_time(start, "after select_camera")
     cap = cv2.VideoCapture(cam_index)
     _debug_time(start, "after VideoCapture")
-    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1920)
-    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 1080)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 3264)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 2448)
     _debug_time(start, "after setting resolution")
     if not cap.isOpened():
         raise RuntimeError("Unable to open camera")
@@ -130,8 +130,8 @@ def scan_document(skip_detection: bool = False, gesture_enabled: bool = True) ->
     _debug_time(start, "after select_camera")
     cap = cv2.VideoCapture(cam_index)
     _debug_time(start, "after VideoCapture")
-    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1920)
-    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 1080)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 3264)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 2448)
     _debug_time(start, "after setting resolution")
     if not cap.isOpened():
         raise RuntimeError("Unable to open camera")

--- a/tests/test_ocr_utils.py
+++ b/tests/test_ocr_utils.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+import importlib
+import sys
+
+import numpy as np
+
+
+def test_save_pdf_uses_high_quality(monkeypatch, tmp_path):
+    fake_cv2 = SimpleNamespace(cvtColor=lambda img, code: img, COLOR_BGR2RGB=0)
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+    import src.ocr_utils as ocr
+    importlib.reload(ocr)
+
+    called = {}
+
+    def fake_image_to_pdf_or_hocr(img, extension, config):
+        called["extension"] = extension
+        called["config"] = config
+        return b"%PDF-1.4"
+
+    monkeypatch.setattr(
+        ocr, "pytesseract", SimpleNamespace(image_to_pdf_or_hocr=fake_image_to_pdf_or_hocr)
+    )
+    monkeypatch.setattr(ocr, "check_tesseract_installation", lambda: None)
+    monkeypatch.chdir(tmp_path)
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    path = ocr.save_pdf(img)
+    assert called["extension"] == "pdf"
+    assert "--dpi 300" in called["config"]
+    assert "jpeg_quality=100" in called["config"]
+    assert path.exists()


### PR DESCRIPTION
## Summary
- Capture images at 3264x2448 resolution for clearer scans
- Generate PDFs with higher image quality via tesseract config
- Add unit test to ensure high-quality PDF generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c9e66d288323a215332318b41fa8