### PR TITLE
Add output directory flag for PDFs

### DIFF
--- a/src/ocr_utils.py
+++ b/src/ocr_utils.py
@@ -33,8 +33,18 @@ def check_tesseract_installation() -> None:
     )
 
 
-def save_pdf(image) -> Path:
-    """Save ``image`` with OCR text as a high-resolution PDF file."""
+def save_pdf(image, output_dir: Path | str | None = None) -> Path:
+    """Save ``image`` with OCR text as a high-resolution PDF file.
+
+    Parameters
+    ----------
+    image:
+        The image to save as a PDF.
+    output_dir:
+        Optional directory in which to write the resulting PDF file.  When not
+        provided, the current working directory is used.
+    """
+
     check_tesseract_installation()
     pil_img = Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
     pil_img.info["dpi"] = (300, 300)
@@ -43,7 +53,9 @@ def save_pdf(image) -> Path:
         pil_img, extension="pdf", config=config
     )
     filename = datetime.now().strftime("%Y%m%d%H%M%S") + ".pdf"
-    path = Path(filename)
+    base_dir = Path(output_dir) if output_dir else Path.cwd()
+    base_dir.mkdir(parents=True, exist_ok=True)
+    path = base_dir / filename
     path.write_bytes(pdf_bytes)
     return path
 

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -84,12 +84,12 @@ def check_tesseract_installation() -> None:  # pragma: no cover - thin wrapper
     return ocr_utils.check_tesseract_installation()
 
 
-def save_pdf(image: np.ndarray):  # pragma: no cover - thin wrapper
+def save_pdf(image: np.ndarray, output_dir: Path | str | None = None):  # pragma: no cover - thin wrapper
     """Proxy to ``ocr_utils.save_pdf`` using local modules."""
     ocr_utils.shutil = shutil
     ocr_utils.Path = Path
     ocr_utils.pytesseract = pytesseract
-    return ocr_utils.save_pdf(image)
+    return ocr_utils.save_pdf(image, output_dir)
 
 
 def open_pdf(path: Path) -> None:  # pragma: no cover - OS-specific side effect
@@ -152,6 +152,7 @@ def scan_document(
     skip_detection: bool = False,
     gesture_enabled: bool = True,
     boost_contrast: bool = True,
+    output_dir: Path | str | None = None,
 ) -> None:
     """Run the interactive document scanner."""
     start = time.perf_counter()
@@ -300,7 +301,7 @@ def scan_document(
         corrected = correct_orientation(warped)
     if boost_contrast:
         corrected = increase_contrast(corrected)
-    pdf_path = save_pdf(corrected)
+    pdf_path = save_pdf(corrected, output_dir)
     print(f"Saved {pdf_path}")
     open_pdf(pdf_path)
 
@@ -328,6 +329,12 @@ def main() -> None:
         action="store_true",
         help="disable 25% contrast boost",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="directory to store generated PDF files",
+    )
     args = parser.parse_args()
     if args.test_camera:
         test_camera()
@@ -336,6 +343,7 @@ def main() -> None:
             skip_detection=args.no_detect,
             gesture_enabled=not args.no_gesture,
             boost_contrast=not args.no_contrast,
+            output_dir=args.output_dir,
         )
 
 

--- a/tests/test_ocr_utils.py
+++ b/tests/test_ocr_utils.py
@@ -29,3 +29,27 @@ def test_save_pdf_uses_high_quality(monkeypatch, tmp_path):
     assert "--dpi 300" in called["config"]
     assert "jpeg_quality=100" in called["config"]
     assert path.exists()
+
+
+def test_save_pdf_custom_directory(monkeypatch, tmp_path):
+    fake_cv2 = SimpleNamespace(cvtColor=lambda img, code: img, COLOR_BGR2RGB=0)
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+    import src.ocr_utils as ocr
+    importlib.reload(ocr)
+
+    called = {}
+
+    def fake_image_to_pdf_or_hocr(img, extension, config):
+        called["extension"] = extension
+        called["config"] = config
+        return b"%PDF-1.4"
+
+    monkeypatch.setattr(
+        ocr, "pytesseract", SimpleNamespace(image_to_pdf_or_hocr=fake_image_to_pdf_or_hocr)
+    )
+    monkeypatch.setattr(ocr, "check_tesseract_installation", lambda: None)
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    out_dir = tmp_path / "pdfs"
+    path = ocr.save_pdf(img, out_dir)
+    assert path.parent == out_dir
+    assert path.exists()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -108,28 +108,46 @@ def test_no_gesture_flag(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
     called = {}
 
-    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast):
-        called["args"] = (skip_detection, gesture_enabled, boost_contrast)
+    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast, output_dir):
+        called["args"] = (skip_detection, gesture_enabled, boost_contrast, output_dir)
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-gesture"])
     scanner.main()
 
-    assert called["args"] == (False, False, True)
+    assert called["args"] == (False, False, True, None)
 
 
 def test_no_contrast_flag(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
     called = {}
 
-    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast):
-        called["args"] = (skip_detection, gesture_enabled, boost_contrast)
+    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast, output_dir):
+        called["args"] = (skip_detection, gesture_enabled, boost_contrast, output_dir)
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-contrast"])
     scanner.main()
 
-    assert called["args"] == (False, True, False)
+    assert called["args"] == (False, True, False, None)
+
+
+def test_output_dir_flag(monkeypatch, tmp_path):
+    scanner = setup_fake_cv2(monkeypatch)
+    called = {}
+
+    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast, output_dir):
+        called["args"] = (skip_detection, gesture_enabled, boost_contrast, output_dir)
+
+    monkeypatch.setattr(scanner, "scan_document", fake_scan)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["scanner", "--output-dir", str(tmp_path)],
+    )
+    scanner.main()
+
+    assert called["args"] == (False, True, True, str(tmp_path))
 
 
 def test_is_v_sign_sideways(monkeypatch):


### PR DESCRIPTION
## Summary
- allow specifying a directory for generated PDF files via `--output-dir`
- default to saving PDFs in the current working directory
- add tests for custom PDF directory and new CLI flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1cd4bdf708323ae360f0c97f085e6