### PR TITLE
Allow configurable document size threshold for detection

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -169,8 +169,17 @@ def scan_document(
     gesture_enabled: bool = True,
     boost_contrast: bool = True,
     output_dir: Path | str | None = None,
+    *,
+    min_area_ratio: float = 0.1,
 ) -> None:
-    """Run the interactive document scanner."""
+    """Run the interactive document scanner.
+
+    Parameters
+    ----------
+    min_area_ratio:
+        Forwarded to :func:`src.image_utils.find_document_contour` to control the
+        minimum size of detectable documents.
+    """
     start = time.perf_counter()
     print("[DEBUG] Starting scan_document")
     cameras = list_cameras()
@@ -227,7 +236,7 @@ def scan_document(
             first_frame = False
         display = frame.copy()
         if not skip_detection:
-            contour = find_document_contour(frame)
+            contour = find_document_contour(frame, min_area_ratio=min_area_ratio)
             if contour is not None:
                 cv2.polylines(display, [contour], True, (0, 255, 0), 2)
 
@@ -304,7 +313,7 @@ def scan_document(
         return
 
     if not skip_detection:
-        contour = find_document_contour(frame)
+        contour = find_document_contour(frame, min_area_ratio=min_area_ratio)
     else:
         contour = None
     if contour is not None and not skip_detection:

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -18,3 +18,25 @@ def test_increase_contrast(monkeypatch):
     result = image_utils.increase_contrast(img)
     expected = np.clip(img * 1.25, 0, 255).astype(np.uint8)
     assert np.array_equal(result, expected)
+
+
+def test_find_document_contour_small_rotated():
+    import cv2
+
+    image_utils = importlib.import_module("src.image_utils")
+    importlib.reload(image_utils)
+
+    frame = np.zeros((200, 200, 3), dtype=np.uint8)
+    rect = ((100, 100), (80, 60), 30)
+    box = cv2.boxPoints(rect).astype(int)
+    cv2.drawContours(frame, [box], -1, (255, 255, 255), -1)
+
+    assert image_utils.find_document_contour(frame, min_area_ratio=0.5) is None
+
+    contour = image_utils.find_document_contour(frame, min_area_ratio=0.1)
+    assert contour is not None
+
+    warped = image_utils.four_point_transform(frame, contour)
+    h, w = warped.shape[:2]
+    assert abs(w - 80) <= 5
+    assert abs(h - 60) <= 5

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -108,36 +108,60 @@ def test_no_gesture_flag(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
     called = {}
 
-    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast, output_dir):
-        called["args"] = (skip_detection, gesture_enabled, boost_contrast, output_dir)
+    def fake_scan(
+        *, skip_detection, gesture_enabled, boost_contrast, output_dir, min_area_ratio=0.1
+    ):
+        called["args"] = (
+            skip_detection,
+            gesture_enabled,
+            boost_contrast,
+            output_dir,
+            min_area_ratio,
+        )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-gesture"])
     scanner.main()
 
-    assert called["args"] == (False, False, True, None)
+    assert called["args"] == (False, False, True, None, 0.1)
 
 
 def test_no_contrast_flag(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
     called = {}
 
-    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast, output_dir):
-        called["args"] = (skip_detection, gesture_enabled, boost_contrast, output_dir)
+    def fake_scan(
+        *, skip_detection, gesture_enabled, boost_contrast, output_dir, min_area_ratio=0.1
+    ):
+        called["args"] = (
+            skip_detection,
+            gesture_enabled,
+            boost_contrast,
+            output_dir,
+            min_area_ratio,
+        )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-contrast"])
     scanner.main()
 
-    assert called["args"] == (False, True, False, None)
+    assert called["args"] == (False, True, False, None, 0.1)
 
 
 def test_output_dir_flag(monkeypatch, tmp_path):
     scanner = setup_fake_cv2(monkeypatch)
     called = {}
 
-    def fake_scan(*, skip_detection, gesture_enabled, boost_contrast, output_dir):
-        called["args"] = (skip_detection, gesture_enabled, boost_contrast, output_dir)
+    def fake_scan(
+        *, skip_detection, gesture_enabled, boost_contrast, output_dir, min_area_ratio=0.1
+    ):
+        called["args"] = (
+            skip_detection,
+            gesture_enabled,
+            boost_contrast,
+            output_dir,
+            min_area_ratio,
+        )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(
@@ -147,7 +171,7 @@ def test_output_dir_flag(monkeypatch, tmp_path):
     )
     scanner.main()
 
-    assert called["args"] == (False, True, True, str(tmp_path))
+    assert called["args"] == (False, True, True, str(tmp_path), 0.1)
 
 
 def test_is_v_sign_sideways(monkeypatch):


### PR DESCRIPTION
## Summary
- make `find_document_contour` accept `min_area_ratio` and relax detection threshold
- pass `min_area_ratio` through `scan_document`
- test small document detection/rotation and update scanner CLI tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d4f5846483239989ca48aebcfe44