### PR TITLE
Add edge-based orientation fallback

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -323,7 +323,7 @@ def scan_document(
     if skip_detection:
         corrected = warped
     else:
-        corrected = correct_orientation(warped)
+        corrected = correct_orientation(warped, contour)
     if boost_contrast:
         corrected = increase_contrast(corrected)
     pdf_path = save_pdf(corrected, output_dir)


### PR DESCRIPTION
## Summary
- add `detect_dominant_edge_angle` using Canny and Hough transforms
- rotate images by dominant edge when contour detection fails
- ensure scanner falls back to edge-based orientation
- test edge-based orientation on a synthetic slanted edge

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d78c63448323b390ac5325d8663e