### PR TITLE
Fix PDF output quality parameter

### DIFF
--- a/src/ocr_utils.py
+++ b/src/ocr_utils.py
@@ -48,7 +48,7 @@ def save_pdf(image, output_dir: Path | str | None = None) -> Path:
     check_tesseract_installation()
     pil_img = Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
     pil_img.info["dpi"] = (300, 300)
-    config = "--dpi 300 -c jpeg_quality=100"
+    config = "--dpi 300 -c jpg_quality=100"
     pdf_bytes = pytesseract.image_to_pdf_or_hocr(
         pil_img, extension="pdf", config=config
     )

--- a/tests/test_ocr_utils.py
+++ b/tests/test_ocr_utils.py
@@ -27,7 +27,7 @@ def test_save_pdf_uses_high_quality(monkeypatch, tmp_path):
     path = ocr.save_pdf(img)
     assert called["extension"] == "pdf"
     assert "--dpi 300" in called["config"]
-    assert "jpeg_quality=100" in called["config"]
+    assert "jpg_quality=100" in called["config"]
     assert path.exists()
 
 


### PR DESCRIPTION
## Summary
- use correct Tesseract `jpg_quality` setting when generating PDFs
- update tests for new parameter name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d7f680a4832389b26636413446de