### PR TITLE
Loop scanning with 30s inactivity timeout

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -169,16 +169,24 @@ def scan_document(
     gesture_enabled: bool = True,
     boost_contrast: bool = True,
     output_dir: Path | str | None = None,
+    timeout: float | None = None,
     *,
     min_area_ratio: float = 0.1,
-) -> None:
+) -> bool:
     """Run the interactive document scanner.
 
     Parameters
     ----------
+    timeout:
+        Maximum number of seconds to wait for a scan request before exiting.
+        ``None`` disables the timeout.
     min_area_ratio:
         Forwarded to :func:`src.image_utils.find_document_contour` to control the
         minimum size of detectable documents.
+    Returns
+    -------
+    bool
+        ``True`` if a document was scanned, ``False`` otherwise.
     """
     start = time.perf_counter()
     print("[DEBUG] Starting scan_document")
@@ -227,6 +235,7 @@ def scan_document(
     frame = None
     contour = None
     first_frame = True
+    wait_start = time.monotonic()
     while True:
         ret, frame = cap.read()
         if not ret:
@@ -307,10 +316,14 @@ def scan_document(
             frame = None
             break
 
+        if timeout is not None and time.monotonic() - wait_start > timeout:
+            frame = None
+            break
+
     cap.release()
     cv2.destroyAllWindows()
     if frame is None:
-        return
+        return False
 
     if not skip_detection:
         contour = find_document_contour(frame, min_area_ratio=min_area_ratio)
@@ -329,6 +342,8 @@ def scan_document(
     pdf_path = save_pdf(corrected, output_dir)
     print(f"Saved {pdf_path}")
     open_pdf(pdf_path)
+
+    return True
 
 
 def main() -> None:
@@ -364,12 +379,14 @@ def main() -> None:
     if args.test_camera:
         test_camera()
     else:
-        scan_document(
+        while scan_document(
             skip_detection=args.no_detect,
             gesture_enabled=not args.no_gesture,
             boost_contrast=not args.no_contrast,
             output_dir=args.output_dir,
-        )
+            timeout=30,
+        ):
+            pass
 
 
 if __name__ == "__main__":

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -109,7 +109,13 @@ def test_no_gesture_flag(monkeypatch):
     called = {}
 
     def fake_scan(
-        *, skip_detection, gesture_enabled, boost_contrast, output_dir, min_area_ratio=0.1
+        *,
+        skip_detection,
+        gesture_enabled,
+        boost_contrast,
+        output_dir,
+        timeout=None,
+        min_area_ratio=0.1,
     ):
         called["args"] = (
             skip_detection,
@@ -131,7 +137,13 @@ def test_no_contrast_flag(monkeypatch):
     called = {}
 
     def fake_scan(
-        *, skip_detection, gesture_enabled, boost_contrast, output_dir, min_area_ratio=0.1
+        *,
+        skip_detection,
+        gesture_enabled,
+        boost_contrast,
+        output_dir,
+        timeout=None,
+        min_area_ratio=0.1,
     ):
         called["args"] = (
             skip_detection,
@@ -153,7 +165,13 @@ def test_output_dir_flag(monkeypatch, tmp_path):
     called = {}
 
     def fake_scan(
-        *, skip_detection, gesture_enabled, boost_contrast, output_dir, min_area_ratio=0.1
+        *,
+        skip_detection,
+        gesture_enabled,
+        boost_contrast,
+        output_dir,
+        timeout=None,
+        min_area_ratio=0.1,
     ):
         called["args"] = (
             skip_detection,


### PR DESCRIPTION
## Summary
- allow `scan_document` to time out if no scan is requested within 30 seconds
- repeat document scans until the timeout is reached
- adjust tests for new scan timeout parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d89a80008323a60d9251d545ceb3