### PR TITLE
Add green bounding-box cues during document detection

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -245,9 +245,9 @@ def scan_document(
             first_frame = False
         display = frame.copy()
         if not skip_detection:
-            contour = find_document_contour(frame, min_area_ratio=min_area_ratio)
-            if contour is not None:
-                cv2.polylines(display, [contour], True, (0, 255, 0), 2)
+            contour = find_document_contour(
+                frame, min_area_ratio=min_area_ratio, preview=display
+            )
 
         if gesture_enabled and hands is not None:
             rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -42,6 +42,25 @@ def test_find_document_contour_small_rotated():
     assert abs(h - 60) <= 5
 
 
+def test_find_document_contour_preview_draws_box():
+    import cv2
+
+    image_utils = importlib.import_module("src.image_utils")
+    importlib.reload(image_utils)
+
+    frame = np.zeros((200, 200, 3), dtype=np.uint8)
+    rect = ((100, 100), (80, 60), 0)
+    box = cv2.boxPoints(rect).astype(int)
+    cv2.drawContours(frame, [box], -1, (255, 255, 255), -1)
+
+    preview = frame.copy()
+    contour = image_utils.find_document_contour(
+        frame, min_area_ratio=0.1, preview=preview
+    )
+    assert contour is not None
+    assert np.any(np.all(preview == (0, 255, 0), axis=-1))
+
+
 def test_correct_orientation_fallback(monkeypatch):
     import cv2
 


### PR DESCRIPTION
## Summary
- overlay detected document contours on a preview image when available
- show live green bounding box in scanner preview using new overlay support
- add regression test for contour overlay drawing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1daf444e883238ba1ffa9ee6569b4