### PR TITLE
Extend scanner exit timeout to 60 seconds

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -395,7 +395,7 @@ def main() -> None:
             gesture_enabled=not args.no_gesture,
             boost_contrast=not args.no_contrast,
             output_dir=args.output_dir,
-            timeout=30,
+            timeout=60,
         ):
             pass
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -192,6 +192,28 @@ def test_output_dir_flag(monkeypatch, tmp_path):
     assert called["args"] == (False, True, True, str(tmp_path), 0.1)
 
 
+def test_default_timeout(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    called = {}
+
+    def fake_scan(
+        *,
+        skip_detection,
+        gesture_enabled,
+        boost_contrast,
+        output_dir,
+        timeout=None,
+        min_area_ratio=0.1,
+    ):
+        called["timeout"] = timeout
+
+    monkeypatch.setattr(scanner, "scan_document", fake_scan)
+    monkeypatch.setattr(sys, "argv", ["scanner"])
+    scanner.main()
+
+    assert called["timeout"] == 60
+
+
 def test_is_v_sign_sideways(monkeypatch):
     """The V gesture should be detected even when rotated 90 degrees."""
     scanner = setup_fake_cv2(monkeypatch)


### PR DESCRIPTION
## Summary
- Increase document scanner's exit timeout from 30s to 60s for longer idle period
- Add regression test ensuring main function passes 60s timeout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e05825f88323811ddda113fcd4ba