### PR TITLE
Remove edge-based orientation fallback

### DIFF
--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 
 import cv2
@@ -112,55 +111,8 @@ def rotate_bound(image: np.ndarray, angle: float) -> np.ndarray:
     return cv2.warpAffine(image, m, (n_w, n_h))
 
 
-def detect_dominant_edge_angle(image: np.ndarray) -> float:
-    """Return the angle of the strongest edge in ``image`` in degrees.
-
-    The image is converted to grayscale, edges are detected using Canny, and a
-    Hough transform is applied.  The line with the highest vote count (``cv2.HoughLines``)
-    or, if none are detected, the longest probabilistic line (``cv2.HoughLinesP``)
-    is used.  The returned angle represents the deviation from the vertical
-    axis; a perfectly upright edge yields ``0``.
-    """
-
-    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-    edges = cv2.Canny(gray, 50, 150)
-    lines = cv2.HoughLines(edges, 1, np.pi / 180, 100)
-    angle = 0.0
-    if lines is not None:
-        rho, theta = lines[0][0]
-        angle = np.degrees(theta)
-        if angle > 90:
-            angle -= 180
-    else:
-        lines_p = cv2.HoughLinesP(
-            edges, 1, np.pi / 180, threshold=100, minLineLength=20, maxLineGap=10
-        )
-        if lines_p is not None:
-            x1, y1, x2, y2 = max(
-                lines_p,
-                key=lambda l: np.hypot(l[0][2] - l[0][0], l[0][3] - l[0][1]),
-            )[0]
-            angle = np.degrees(np.arctan2(y2 - y1, x2 - x1)) - 90
-            if angle > 90:
-                angle -= 180
-            elif angle <= -90:
-                angle += 180
-    return angle
-
-
-def correct_orientation(image: np.ndarray, contour: np.ndarray | None = None) -> np.ndarray:
-    """Rotate ``image`` using edge detection and Tesseract orientation.
-
-    If ``contour`` is ``None`` (indicating document contour detection failed),
-    the function first estimates the dominant edge angle and rotates the image
-    to make that edge upright.  It then performs an OCR-based orientation
-    detection to correct any remaining 90° multiples.
-    """
-
-    if contour is None:
-        theta = detect_dominant_edge_angle(image)
-        if abs(theta) > 0.1:
-            image = rotate_bound(image, theta)
+def correct_orientation(image: np.ndarray) -> np.ndarray:
+    """Rotate ``image`` using Tesseract orientation detection."""
 
     check_tesseract_installation()
     try:
@@ -184,7 +136,6 @@ __all__ = [
     "order_points",
     "four_point_transform",
     "rotate_bound",
-    "detect_dominant_edge_angle",
     "correct_orientation",
     "increase_contrast",
 ]

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -347,7 +347,7 @@ def scan_document(
     if skip_detection:
         corrected = warped
     else:
-        corrected = correct_orientation(warped, contour)
+        corrected = correct_orientation(warped)
     if boost_contrast:
         corrected = increase_contrast(corrected)
     pdf_path = save_pdf(corrected, output_dir)

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -59,22 +59,3 @@ def test_find_document_contour_preview_draws_box():
     )
     assert contour is not None
     assert np.any(np.all(preview == (0, 255, 0), axis=-1))
-
-
-def test_correct_orientation_fallback(monkeypatch):
-    import cv2
-
-    fake_pytesseract = types.SimpleNamespace(image_to_osd=lambda img: "Rotate: 0")
-    monkeypatch.setitem(sys.modules, "pytesseract", fake_pytesseract)
-
-    image_utils = importlib.import_module("src.image_utils")
-    importlib.reload(image_utils)
-    monkeypatch.setattr(image_utils, "check_tesseract_installation", lambda: None)
-
-    img = np.zeros((100, 100, 3), dtype=np.uint8)
-    cv2.line(img, (50, 0), (50, 99), (255, 255, 255), 2)
-    rotated = image_utils.rotate_bound(img, 30)
-
-    corrected = image_utils.correct_orientation(rotated, None)
-    angle = image_utils.detect_dominant_edge_angle(corrected)
-    assert abs(angle) < 1

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -341,7 +341,7 @@ def test_scan_document_reuses_camera(monkeypatch):
     monkeypatch.setattr(scanner, "save_pdf", lambda img, out: Path("out.pdf"))
     monkeypatch.setattr(scanner, "open_pdf", lambda _p: None)
     monkeypatch.setattr(scanner, "find_document_contour", lambda *a, **k: None)
-    monkeypatch.setattr(scanner, "correct_orientation", lambda img, _c: img)
+    monkeypatch.setattr(scanner, "correct_orientation", lambda img: img)
     monkeypatch.setattr(scanner, "four_point_transform", lambda img, _c: img)
     monkeypatch.setattr(scanner, "sys", SimpleNamespace(stdin=SimpleNamespace(read=lambda n: "")))
     monkeypatch.setattr(scanner, "PREVIEW_SCALE", 1.0)


### PR DESCRIPTION
## Summary
- drop edge-based orientation detection fallback
- rely solely on Tesseract for orientation in `correct_orientation`
- update scanner and tests for new orientation flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e333c18083239acfc8972e99ddcd