### PR TITLE
Denoise captured images to reduce JPEG artifacts

### DIFF
--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -131,6 +131,20 @@ def increase_contrast(image: np.ndarray, factor: float = 1.25) -> np.ndarray:
     return cv2.convertScaleAbs(image, alpha=factor, beta=0)
 
 
+def reduce_jpeg_artifacts(image: np.ndarray) -> np.ndarray:
+    """Denoise ``image`` to lessen visible JPEG compression artifacts.
+
+    The scanner captures frames from a webcam which commonly delivers JPEG
+    compressed images.  Re-encoding those images can exaggerate blocking and
+    ringing artifacts.  OpenCV's ``fastNlMeansDenoisingColored`` performs a
+    non-local means filter that smooths out compression noise while preserving
+    edges, providing a cleaner source for downstream OCR and PDF generation.
+    """
+
+    # Parameters are tuned for a good balance between smoothing and detail.
+    return cv2.fastNlMeansDenoisingColored(image, None, 10, 10, 7, 21)
+
+
 __all__ = [
     "find_document_contour",
     "order_points",
@@ -138,4 +152,5 @@ __all__ = [
     "rotate_bound",
     "correct_orientation",
     "increase_contrast",
+    "reduce_jpeg_artifacts",
 ]

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -22,6 +22,7 @@ from .image_utils import (
     find_document_contour,
     four_point_transform,
     increase_contrast,
+    reduce_jpeg_artifacts,
 )
 from . import ocr_utils
 
@@ -350,6 +351,8 @@ def scan_document(
         corrected = correct_orientation(warped)
     if boost_contrast:
         corrected = increase_contrast(corrected)
+    # Lightly denoise the frame to reduce visible JPEG artifacts before saving
+    corrected = reduce_jpeg_artifacts(corrected)
     pdf_path = save_pdf(corrected, output_dir)
     print(f"Saved {pdf_path}")
     open_pdf(pdf_path)

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -20,6 +20,25 @@ def test_increase_contrast(monkeypatch):
     assert np.array_equal(result, expected)
 
 
+def test_reduce_jpeg_artifacts(monkeypatch):
+    called = {}
+
+    def fake_denoise(img, _dst, h, hColor, template, search):
+        called["args"] = (h, hColor, template, search)
+        return img
+
+    fake_cv2 = types.SimpleNamespace(fastNlMeansDenoisingColored=fake_denoise)
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+
+    image_utils = importlib.import_module("src.image_utils")
+    importlib.reload(image_utils)
+
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    result = image_utils.reduce_jpeg_artifacts(img)
+    assert result is img
+    assert called["args"] == (10, 10, 7, 21)
+
+
 def test_find_document_contour_small_rotated():
     import cv2
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -338,6 +338,7 @@ def test_scan_document_reuses_camera(monkeypatch):
     monkeypatch.setattr(scanner, "select_camera", fake_select)
     monkeypatch.setattr(scanner, "_create_window", lambda *_a: None)
     monkeypatch.setattr(scanner, "increase_contrast", lambda img: img)
+    monkeypatch.setattr(scanner, "reduce_jpeg_artifacts", lambda img: img)
     monkeypatch.setattr(scanner, "save_pdf", lambda img, out: Path("out.pdf"))
     monkeypatch.setattr(scanner, "open_pdf", lambda _p: None)
     monkeypatch.setattr(scanner, "find_document_contour", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- add `reduce_jpeg_artifacts` helper using OpenCV's non-local means denoiser
- apply denoising to scanned frames before saving PDFs
- test artifact reduction helper and update scanner tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e4f78ce08323ab26c89e1a583954