### PR TITLE
Replace bounding box with long edge detection

### DIFF
--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -2,128 +2,48 @@
 
 from __future__ import annotations
 
-import re
-
 import cv2
 import numpy as np
-import pytesseract
-
-from .ocr_utils import check_tesseract_installation
 
 
-def find_document_contour(
-    frame: np.ndarray,
+def find_long_edges(
+    image: np.ndarray,
     *,
-    min_area_ratio: float = 0.1,
-    preview: np.ndarray | None = None,
-) -> np.ndarray | None:
-    """Locate a rectangular contour in ``frame``.
+    min_length_ratio: float = 0.25,
+    max_edges: int = 20,
+) -> list[tuple[int, int, int, int, float]]:
+    """Return long edges detected in ``image``.
 
-    Parameters
-    ----------
-    frame:
-        Image in which to search for the document.
-    min_area_ratio:
-        Minimum area (as a fraction of the full frame) that a contour must
-        cover to be considered a document.  Smaller values allow detection of
-        documents that do not fill most of the camera view.
-    preview:
-        Optional image on which a visual cue of the detected contour will be
-        drawn.  When provided and a contour is found, a green bounding box is
-        overlaid onto this image.  ``preview`` is modified in-place.
+    Edges are detected using Canny edge detection followed by a probabilistic
+    Hough transform.  Only line segments longer than ``min_length_ratio`` times
+    the smaller image dimension are returned.  The segments are sorted by
+    length from longest to shortest and limited to ``max_edges`` entries.
+
+    Returns a list of ``(x1, y1, x2, y2, angle)`` tuples where ``angle`` is the
+    absolute angle of the line segment in degrees.
     """
-    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
     blurred = cv2.GaussianBlur(gray, (5, 5), 0)
-    edged = cv2.Canny(blurred, 50, 150)
-    contours, _ = cv2.findContours(
-        edged.copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+    edges = cv2.Canny(blurred, 50, 150)
+
+    h, w = gray.shape[:2]
+    min_len = int(min(h, w) * min_length_ratio)
+    lines = cv2.HoughLinesP(
+        edges, 1, np.pi / 180, threshold=50, minLineLength=min_len, maxLineGap=10
     )
-    height, width = frame.shape[:2]
-    frame_area = width * height
-    contours = sorted(contours, key=cv2.contourArea, reverse=True)
-    for c in contours:
-        peri = cv2.arcLength(c, True)
-        approx = cv2.approxPolyDP(c, 0.02 * peri, True)
-        area = cv2.contourArea(c)
-        if len(approx) == 4 and area > min_area_ratio * frame_area:
-            if preview is not None:
-                cv2.polylines(preview, [approx.astype(int)], True, (0, 255, 0), 2)
-            return approx
-    if contours:
-        area = cv2.contourArea(contours[0])
-        if area > max(min_area_ratio, 0.9) * frame_area:
-            fallback = np.array(
-                [[0, 0], [width - 1, 0], [width - 1, height - 1], [0, height - 1]],
-                dtype=np.float32,
-            )
-            if preview is not None:
-                cv2.polylines(preview, [fallback.astype(int)], True, (0, 255, 0), 2)
-            return fallback
-    return None
 
+    results: list[tuple[int, int, int, int, float, float]] = []
+    if lines is not None:
+        for x1, y1, x2, y2 in lines[:, 0]:
+            length = float(np.hypot(x2 - x1, y2 - y1))
+            angle = abs(np.degrees(np.arctan2(y2 - y1, x2 - x1)))
+            if angle > 180:
+                angle -= 180
+            results.append((x1, y1, x2, y2, angle, length))
+        results.sort(key=lambda x: x[5], reverse=True)
 
-def order_points(pts: np.ndarray) -> np.ndarray:
-    """Return a consistent ordering of the four points of ``pts``."""
-    rect = np.zeros((4, 2), dtype="float32")
-    pts = pts.reshape(4, 2)
-    s = pts.sum(axis=1)
-    rect[0] = pts[np.argmin(s)]
-    rect[2] = pts[np.argmax(s)]
-    diff = np.diff(pts, axis=1)
-    rect[1] = pts[np.argmin(diff)]
-    rect[3] = pts[np.argmax(diff)]
-    return rect
-
-
-def four_point_transform(image: np.ndarray, pts: np.ndarray) -> np.ndarray:
-    """Perform a perspective transform of ``image`` using ``pts``."""
-    rect = order_points(pts)
-    (tl, tr, br, bl) = rect
-    width_a = np.linalg.norm(br - bl)
-    width_b = np.linalg.norm(tr - tl)
-    max_width = int(max(width_a, width_b))
-    height_a = np.linalg.norm(tr - br)
-    height_b = np.linalg.norm(tl - bl)
-    max_height = int(max(height_a, height_b))
-    dst = np.array(
-        [
-            [0, 0],
-            [max_width - 1, 0],
-            [max_width - 1, max_height - 1],
-            [0, max_height - 1],
-        ],
-        dtype="float32",
-    )
-    m = cv2.getPerspectiveTransform(rect, dst)
-    return cv2.warpPerspective(image, m, (max_width, max_height))
-
-
-def rotate_bound(image: np.ndarray, angle: float) -> np.ndarray:
-    """Rotate ``image`` by ``angle`` degrees without cropping."""
-    (h, w) = image.shape[:2]
-    m = cv2.getRotationMatrix2D((w / 2, h / 2), -angle, 1.0)
-    cos = np.abs(m[0, 0])
-    sin = np.abs(m[0, 1])
-    n_w = int((h * sin) + (w * cos))
-    n_h = int((h * cos) + (w * sin))
-    m[0, 2] += (n_w / 2) - w / 2
-    m[1, 2] += (n_h / 2) - h / 2
-    return cv2.warpAffine(image, m, (n_w, n_h))
-
-
-def correct_orientation(image: np.ndarray) -> np.ndarray:
-    """Rotate ``image`` using Tesseract orientation detection."""
-
-    check_tesseract_installation()
-    try:
-        osd = pytesseract.image_to_osd(image)
-        match = re.search(r"Rotate: (\d+)", osd)
-        angle = int(match.group(1)) if match else 0
-    except Exception:
-        angle = 0
-    if angle in (90, 180, 270):
-        image = rotate_bound(image, angle)
-    return image
+    return [(x1, y1, x2, y2, angle) for x1, y1, x2, y2, angle, _ in results[:max_edges]]
 
 
 def increase_contrast(image: np.ndarray, factor: float = 1.25) -> np.ndarray:
@@ -132,25 +52,8 @@ def increase_contrast(image: np.ndarray, factor: float = 1.25) -> np.ndarray:
 
 
 def reduce_jpeg_artifacts(image: np.ndarray) -> np.ndarray:
-    """Denoise ``image`` to lessen visible JPEG compression artifacts.
-
-    The scanner captures frames from a webcam which commonly delivers JPEG
-    compressed images.  Re-encoding those images can exaggerate blocking and
-    ringing artifacts.  OpenCV's ``fastNlMeansDenoisingColored`` performs a
-    non-local means filter that smooths out compression noise while preserving
-    edges, providing a cleaner source for downstream OCR and PDF generation.
-    """
-
-    # Parameters are tuned for a good balance between smoothing and detail.
+    """Denoise ``image`` to lessen visible JPEG compression artifacts."""
     return cv2.fastNlMeansDenoisingColored(image, None, 10, 10, 7, 21)
 
 
-__all__ = [
-    "find_document_contour",
-    "order_points",
-    "four_point_transform",
-    "rotate_bound",
-    "correct_orientation",
-    "increase_contrast",
-    "reduce_jpeg_artifacts",
-]
+__all__ = ["find_long_edges", "increase_contrast", "reduce_jpeg_artifacts"]

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -111,28 +111,24 @@ def test_no_gesture_flag(monkeypatch):
 
     def fake_scan(
         *,
-        skip_detection,
         gesture_enabled,
         boost_contrast,
         output_dir,
         timeout=None,
         stack_count=10,
-        min_area_ratio=0.1,
     ):
         called["args"] = (
-            skip_detection,
             gesture_enabled,
             boost_contrast,
             output_dir,
             stack_count,
-            min_area_ratio,
         )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-gesture"])
     scanner.main()
 
-    assert called["args"] == (False, False, True, None, 10, 0.1)
+    assert called["args"] == (False, True, None, 10)
 
 
 def test_no_contrast_flag(monkeypatch):
@@ -141,28 +137,24 @@ def test_no_contrast_flag(monkeypatch):
 
     def fake_scan(
         *,
-        skip_detection,
         gesture_enabled,
         boost_contrast,
         output_dir,
         timeout=None,
         stack_count=10,
-        min_area_ratio=0.1,
     ):
         called["args"] = (
-            skip_detection,
             gesture_enabled,
             boost_contrast,
             output_dir,
             stack_count,
-            min_area_ratio,
         )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-contrast"])
     scanner.main()
 
-    assert called["args"] == (False, True, False, None, 10, 0.1)
+    assert called["args"] == (True, False, None, 10)
 
 
 def test_output_dir_flag(monkeypatch, tmp_path):
@@ -171,21 +163,17 @@ def test_output_dir_flag(monkeypatch, tmp_path):
 
     def fake_scan(
         *,
-        skip_detection,
         gesture_enabled,
         boost_contrast,
         output_dir,
         timeout=None,
         stack_count=10,
-        min_area_ratio=0.1,
     ):
         called["args"] = (
-            skip_detection,
             gesture_enabled,
             boost_contrast,
             output_dir,
             stack_count,
-            min_area_ratio,
         )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
@@ -196,7 +184,7 @@ def test_output_dir_flag(monkeypatch, tmp_path):
     )
     scanner.main()
 
-    assert called["args"] == (False, True, True, str(tmp_path), 10, 0.1)
+    assert called["args"] == (True, True, str(tmp_path), 10)
 
 
 def test_default_timeout(monkeypatch):
@@ -205,13 +193,11 @@ def test_default_timeout(monkeypatch):
 
     def fake_scan(
         *,
-        skip_detection,
         gesture_enabled,
         boost_contrast,
         output_dir,
         timeout=None,
         stack_count=10,
-        min_area_ratio=0.1,
     ):
         called["timeout"] = timeout
 
@@ -343,14 +329,12 @@ def test_scan_document_reuses_camera(monkeypatch):
     monkeypatch.setattr(scanner, "reduce_jpeg_artifacts", lambda img: img)
     monkeypatch.setattr(scanner, "save_pdf", lambda img, out: Path("out.pdf"))
     monkeypatch.setattr(scanner, "open_pdf", lambda _p: None)
-    monkeypatch.setattr(scanner, "find_document_contour", lambda *a, **k: None)
-    monkeypatch.setattr(scanner, "correct_orientation", lambda img: img)
-    monkeypatch.setattr(scanner, "four_point_transform", lambda img, _c: img)
+    monkeypatch.setattr(scanner, "find_long_edges", lambda *a, **k: [])
     monkeypatch.setattr(scanner, "sys", SimpleNamespace(stdin=SimpleNamespace(read=lambda n: "")))
     monkeypatch.setattr(scanner, "PREVIEW_SCALE", 1.0)
 
-    scanner.scan_document(skip_detection=True, gesture_enabled=False, boost_contrast=False)
-    scanner.scan_document(skip_detection=True, gesture_enabled=False, boost_contrast=False)
+    scanner.scan_document(gesture_enabled=False, boost_contrast=False)
+    scanner.scan_document(gesture_enabled=False, boost_contrast=False)
 
     assert calls == {"list": 1, "select": 1, "open": 1}
 
@@ -390,10 +374,9 @@ def test_scan_document_stacks_frames(monkeypatch):
     monkeypatch.setattr(scanner, "list_cameras", lambda: [(0, "cam")])
     monkeypatch.setattr(scanner, "select_camera", lambda _c: 0)
     monkeypatch.setattr(scanner, "_create_window", lambda *_: None)
-    monkeypatch.setattr(scanner, "find_document_contour", lambda *a, **k: None)
-    monkeypatch.setattr(scanner, "correct_orientation", lambda img: img)
-    monkeypatch.setattr(scanner, "four_point_transform", lambda img, _c: img)
+    monkeypatch.setattr(scanner, "find_long_edges", lambda *a, **k: [])
     monkeypatch.setattr(scanner, "increase_contrast", lambda img: img)
+    monkeypatch.setattr(scanner, "reduce_jpeg_artifacts", lambda img: img)
     saved = {}
 
     def fake_save(img, out):
@@ -406,7 +389,6 @@ def test_scan_document_stacks_frames(monkeypatch):
     monkeypatch.setattr(scanner, "PREVIEW_SCALE", 1.0)
 
     scanner.scan_document(
-        skip_detection=True,
         gesture_enabled=False,
         boost_contrast=False,
         stack_count=3,


### PR DESCRIPTION
## Summary
- remove bounding box and automatic rotation logic
- draw top 20 long edges and color code based on alignment
- simplify tests for new edge detection API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b270e70bb883238e051f2737abe861