### PR TITLE
Improve detection of edges extending beyond frame

### DIFF
--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -71,3 +71,37 @@ def test_find_long_edges_detects_axes(monkeypatch):
     angles = [angle for *_coords, angle in edges]
     assert any(abs(a) <= 3 for a in angles)
     assert any(abs(a - 90) <= 3 for a in angles)
+
+
+def test_find_long_edges_extends_short_segments(monkeypatch):
+    def fake_cvtColor(img, code):
+        return img[:, :, 0]
+
+    def fake_blur(img, k, s):
+        return img
+
+    def fake_canny(img, t1, t2):
+        return img
+
+    def fake_hough(edges, rho, theta, **kwargs):
+        return np.array([[[80, 100, 100, 100]]])
+
+    fake_cv2 = types.SimpleNamespace(
+        cvtColor=fake_cvtColor,
+        COLOR_BGR2GRAY=0,
+        GaussianBlur=fake_blur,
+        Canny=fake_canny,
+        HoughLinesP=fake_hough,
+    )
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+
+    image_utils = importlib.import_module("src.image_utils")
+    importlib.reload(image_utils)
+
+    frame = np.full((200, 200, 3), 255, dtype=np.uint8)
+
+    edges = image_utils.find_long_edges(frame, min_length_ratio=0.2)
+    assert edges
+    x1, y1, x2, y2, _ = edges[0]
+    assert (x1, y1) == (0, 100)
+    assert (x2, y2) == (199, 100)


### PR DESCRIPTION
## Summary
- extend detected line segments to image bounds and re-check length
- lower detection threshold to include partial segments
- add regression test for boundary-spanning edges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b27609fc088323b25fb4f39e44acae