### PR TITLE
feat: make edge angle threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The steps below assume no prior Python knowledge.
   - **Windows**: double‑click `run_lens2pdf.bat` or run `python src/scanner.py` from an activated virtual environment.
   - **macOS/Linux**: run `python src/scanner.py` from an activated virtual environment.
 - Optional camera test: `python src/scanner.py --test-camera`.
+- Adjust edge straightness tolerance (default 2°):
+  `python src/scanner.py --angle-threshold 5`.
 - Position your document in view. When ready, show a **V sign** (or press `s`). The app captures the page, saves a PDF in the current directory and opens it. Press `q` to quit.
 
 ## Running tests

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -197,6 +197,7 @@ def scan_document(
     output_dir: Path | str | None = None,
     timeout: float | None = None,
     stack_count: int = 10,
+    angle_threshold: float = 2,
 ) -> bool:
     """Run the interactive document scanner.
 
@@ -209,6 +210,9 @@ def scan_document(
         Number of frames to average together for a single scan.  Using multiple
         frames can reduce noise and slightly improve effective resolution when
         the document is stationary.
+    angle_threshold:
+        Maximum allowed deviation in degrees for edges to be drawn green in the
+        preview.
     Returns
     -------
     bool
@@ -278,7 +282,7 @@ def scan_document(
         edges = find_long_edges(frame)
         for x1, y1, x2, y2, angle in edges:
             diff = min(abs(angle), abs(angle - 90))
-            color = (0, 255, 0) if diff <= 3 else (0, 0, 255)
+            color = (0, 255, 0) if diff <= angle_threshold else (0, 0, 255)
             cv2.line(display, (x1, y1), (x2, y2), color, 2)
 
         if gesture_enabled and hands is not None:
@@ -398,6 +402,12 @@ def main() -> None:
         default=None,
         help="directory to store generated PDF files",
     )
+    parser.add_argument(
+        "--angle-threshold",
+        type=float,
+        default=2,
+        help="maximum deviation in degrees for edges to appear green",
+    )
     args = parser.parse_args()
     if args.test_camera:
         test_camera()
@@ -407,6 +417,7 @@ def main() -> None:
             boost_contrast=not args.no_contrast,
             output_dir=args.output_dir,
             timeout=60,
+            angle_threshold=args.angle_threshold,
         ):
             pass
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -116,19 +116,21 @@ def test_no_gesture_flag(monkeypatch):
         output_dir,
         timeout=None,
         stack_count=10,
+        angle_threshold=2,
     ):
         called["args"] = (
             gesture_enabled,
             boost_contrast,
             output_dir,
             stack_count,
+            angle_threshold,
         )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-gesture"])
     scanner.main()
 
-    assert called["args"] == (False, True, None, 10)
+    assert called["args"] == (False, True, None, 10, 2)
 
 
 def test_no_contrast_flag(monkeypatch):
@@ -142,19 +144,21 @@ def test_no_contrast_flag(monkeypatch):
         output_dir,
         timeout=None,
         stack_count=10,
+        angle_threshold=2,
     ):
         called["args"] = (
             gesture_enabled,
             boost_contrast,
             output_dir,
             stack_count,
+            angle_threshold,
         )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-contrast"])
     scanner.main()
 
-    assert called["args"] == (True, False, None, 10)
+    assert called["args"] == (True, False, None, 10, 2)
 
 
 def test_output_dir_flag(monkeypatch, tmp_path):
@@ -168,12 +172,14 @@ def test_output_dir_flag(monkeypatch, tmp_path):
         output_dir,
         timeout=None,
         stack_count=10,
+        angle_threshold=2,
     ):
         called["args"] = (
             gesture_enabled,
             boost_contrast,
             output_dir,
             stack_count,
+            angle_threshold,
         )
 
     monkeypatch.setattr(scanner, "scan_document", fake_scan)
@@ -184,7 +190,29 @@ def test_output_dir_flag(monkeypatch, tmp_path):
     )
     scanner.main()
 
-    assert called["args"] == (True, True, str(tmp_path), 10)
+    assert called["args"] == (True, True, str(tmp_path), 10, 2)
+
+
+def test_angle_threshold_flag(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    called = {}
+
+    def fake_scan(
+        *,
+        gesture_enabled,
+        boost_contrast,
+        output_dir,
+        timeout=None,
+        stack_count=10,
+        angle_threshold=2,
+    ):
+        called["angle_threshold"] = angle_threshold
+
+    monkeypatch.setattr(scanner, "scan_document", fake_scan)
+    monkeypatch.setattr(sys, "argv", ["scanner", "--angle-threshold", "5"])
+    scanner.main()
+
+    assert called["angle_threshold"] == 5
 
 
 def test_default_timeout(monkeypatch):
@@ -198,6 +226,7 @@ def test_default_timeout(monkeypatch):
         output_dir,
         timeout=None,
         stack_count=10,
+        angle_threshold=2,
     ):
         called["timeout"] = timeout
 


### PR DESCRIPTION
## Summary
- make edge straightness threshold configurable with `--angle-threshold`
- draw edges red when deviating more than configurable threshold (default 2°)
- document and test the new CLI option

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b27d934afc8323ade8b889c22e986a