### PR TITLE
Handle quit key and window close

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -185,7 +185,12 @@ def test_camera() -> None:
                 interpolation=cv2.INTER_AREA,
             )
         cv2.imshow("Camera Test", preview)
-        if cv2.waitKey(1) & 0xFF == ord("q"):
+        key = cv2.waitKey(1)
+        # Allow quitting either by pressing ``q`` or closing the window
+        if (
+            (key != -1 and chr(key & 0xFF).lower() == "q")
+            or cv2.getWindowProperty("Camera Test", cv2.WND_PROP_VISIBLE) < 1
+        ):
             break
     cap.release()
     cv2.destroyAllWindows()
@@ -334,17 +339,19 @@ def scan_document(
             )
         cv2.imshow("Scanner", display)
 
-        key = cv2.waitKey(1) & 0xFF
+        key = cv2.waitKey(1)
+        key_char = ""
+        if key != -1:
+            key_char = chr(key & 0xFF).lower()
         while not stdin_q.empty():
-            char = stdin_q.get_nowait().lower()
-            if char == "q":
-                key = ord("q")
-            elif char == "s":
-                key = ord("s")
+            key_char = stdin_q.get_nowait().lower()
 
-        if key in (ord("s"), 13):
+        if key_char == "s" or key == 13:
             break
-        if key == ord("q"):
+        if (
+            key_char == "q"
+            or cv2.getWindowProperty("Scanner", cv2.WND_PROP_VISIBLE) < 1
+        ):
             frame = None
             break
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -319,6 +319,8 @@ def test_scan_document_reuses_camera(monkeypatch):
         waitKey=lambda *a, **k: ord("s"),
         resize=lambda img, *a, **k: img,
         destroyAllWindows=lambda: None,
+        getWindowProperty=lambda *a, **k: 1,
+        WND_PROP_VISIBLE=0,
     )
 
     monkeypatch.setattr(scanner, "cv2", fake_cv2)
@@ -369,6 +371,8 @@ def test_scan_document_stacks_frames(monkeypatch):
         waitKey=lambda *a, **k: ord("s"),
         resize=lambda img, *a, **k: img,
         destroyAllWindows=lambda: None,
+        getWindowProperty=lambda *a, **k: 1,
+        WND_PROP_VISIBLE=0,
     )
 
     monkeypatch.setattr(scanner, "cv2", fake_cv2)
@@ -398,4 +402,106 @@ def test_scan_document_stacks_frames(monkeypatch):
 
     # Frames values were 0, 1 and 2 -> average = 1
     assert saved["img"][0, 0, 0] == 1
+
+
+def test_scan_document_quits_on_q(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+
+    class FakeCapture:
+        def __init__(self, index):
+            pass
+
+        def set(self, *_):
+            pass
+
+        def isOpened(self):
+            return True
+
+        def read(self):
+            return True, np.zeros((1, 1, 3), dtype=np.uint8)
+
+        def release(self):
+            pass
+
+    fake_cv2 = SimpleNamespace(
+        VideoCapture=FakeCapture,
+        CAP_PROP_FRAME_WIDTH=0,
+        CAP_PROP_FRAME_HEIGHT=0,
+        imshow=lambda *a, **k: None,
+        waitKey=lambda *a, **k: ord("q"),
+        resize=lambda img, *a, **k: img,
+        destroyAllWindows=lambda: None,
+        getWindowProperty=lambda *a, **k: 1,
+        WND_PROP_VISIBLE=0,
+    )
+
+    monkeypatch.setattr(scanner, "cv2", fake_cv2)
+    monkeypatch.setattr(scanner, "list_cameras", lambda: [(0, "cam")])
+    monkeypatch.setattr(scanner, "select_camera", lambda _c: 0)
+    monkeypatch.setattr(scanner, "_create_window", lambda *_: None)
+    monkeypatch.setattr(scanner, "find_long_edges", lambda *a, **k: [])
+    monkeypatch.setattr(scanner, "increase_contrast", lambda img: img)
+    monkeypatch.setattr(scanner, "reduce_jpeg_artifacts", lambda img: img)
+    monkeypatch.setattr(scanner, "correct_orientation", lambda img: img)
+    monkeypatch.setattr(scanner, "save_pdf", lambda img, out: Path("out.pdf"))
+    monkeypatch.setattr(scanner, "open_pdf", lambda _p: None)
+    monkeypatch.setattr(
+        scanner, "sys", SimpleNamespace(stdin=SimpleNamespace(read=lambda n: ""))
+    )
+    monkeypatch.setattr(scanner, "PREVIEW_SCALE", 1.0)
+
+    assert (
+        scanner.scan_document(gesture_enabled=False, boost_contrast=False) is False
+    )
+
+
+def test_scan_document_quits_on_window_close(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+
+    class FakeCapture:
+        def __init__(self, index):
+            pass
+
+        def set(self, *_):
+            pass
+
+        def isOpened(self):
+            return True
+
+        def read(self):
+            return True, np.zeros((1, 1, 3), dtype=np.uint8)
+
+        def release(self):
+            pass
+
+    fake_cv2 = SimpleNamespace(
+        VideoCapture=FakeCapture,
+        CAP_PROP_FRAME_WIDTH=0,
+        CAP_PROP_FRAME_HEIGHT=0,
+        imshow=lambda *a, **k: None,
+        waitKey=lambda *a, **k: -1,
+        resize=lambda img, *a, **k: img,
+        destroyAllWindows=lambda: None,
+        getWindowProperty=lambda *a, **k: 0,
+        WND_PROP_VISIBLE=0,
+    )
+
+    monkeypatch.setattr(scanner, "cv2", fake_cv2)
+    monkeypatch.setattr(scanner, "list_cameras", lambda: [(0, "cam")])
+    monkeypatch.setattr(scanner, "select_camera", lambda _c: 0)
+    monkeypatch.setattr(scanner, "_create_window", lambda *_: None)
+    monkeypatch.setattr(scanner, "find_long_edges", lambda *a, **k: [])
+    monkeypatch.setattr(scanner, "increase_contrast", lambda img: img)
+    monkeypatch.setattr(scanner, "reduce_jpeg_artifacts", lambda img: img)
+    monkeypatch.setattr(scanner, "correct_orientation", lambda img: img)
+    monkeypatch.setattr(scanner, "save_pdf", lambda img, out: Path("out.pdf"))
+    monkeypatch.setattr(scanner, "open_pdf", lambda _p: None)
+    monkeypatch.setattr(
+        scanner, "sys", SimpleNamespace(stdin=SimpleNamespace(read=lambda n: ""))
+    )
+    monkeypatch.setattr(scanner, "PREVIEW_SCALE", 1.0)
+
+    assert (
+        scanner.scan_document(gesture_enabled=False, boost_contrast=False) is False
+    )
 


### PR DESCRIPTION
## Summary
- Ensure the camera and scanner windows close immediately when pressing `q` or closing the window
- Refactor key handling for scans to support both console input and window events
- Add regression tests for quitting via `q` and window close

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b27eb027c4832397d598782ceffdab