### PR TITLE
Reduce preview window size and improve video performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ python -m src.scanner
 Hold a document in view and show a V sign (or press `s`) to capture. Press `q`
 to quit.
 
+### Preview window and performance
+
+The preview window is scaled to 25% of the camera resolution and the capture
+defaults to 1600×1200 to keep the video feed responsive. These values can be
+adjusted in `src/scanner.py` via `PREVIEW_SCALE`, `CAPTURE_WIDTH` and
+`CAPTURE_HEIGHT` if your hardware performs better at different settings.
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- shrink preview window to quarter size with new configuration constants
- lower default capture resolution to 1600x1200 for smoother feed
- document new defaults in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b32e7ec6188323b6a9585e0fc44f3c