### PR TITLE
Open compressed video stream

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -171,8 +171,16 @@ def _open_capture(cam_index: int, cameras) -> cv2.VideoCapture:
         backend_const = getattr(cv2, const_name, None)
 
     if backend_const is not None:
-        return cv2.VideoCapture(cam_index, backend_const)
-    return cv2.VideoCapture(cam_index)
+        return cv2.VideoCapture(
+            cam_index,
+            backend_const,
+            [cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG")],
+        )
+    return cv2.VideoCapture(
+        cam_index,
+        getattr(cv2, "CAP_ANY", 0),
+        [cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG")],
+    )
 
 
 def check_tesseract_installation() -> None:  # pragma: no cover - thin wrapper

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -11,7 +11,7 @@ def setup_fake_cv2(monkeypatch):
     """Return the scanner module loaded with a stubbed cv2 module."""
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             self.index = index
 
         def isOpened(self):
@@ -31,6 +31,8 @@ def setup_fake_cv2(monkeypatch):
     fake_cv2 = SimpleNamespace(
         videoio_registry=registry,
         VideoCapture=FakeCapture,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         __version__="4.8.0",
     )
     # ``scanner`` imports ``cv2``, ``numpy`` and ``pytesseract`` at module import
@@ -376,7 +378,7 @@ def test_scan_document_reuses_camera(monkeypatch):
         return 0
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             calls["open"] += 1
 
         def set(self, *_args):
@@ -395,6 +397,8 @@ def test_scan_document_reuses_camera(monkeypatch):
         VideoCapture=FakeCapture,
         CAP_PROP_FRAME_WIDTH=0,
         CAP_PROP_FRAME_HEIGHT=0,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         imshow=lambda *a, **k: None,
         waitKey=lambda *a, **k: ord("s"),
         resize=lambda img, *a, **k: img,
@@ -426,7 +430,7 @@ def test_scan_document_stacks_frames(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             self.count = 0
 
         def set(self, *_):
@@ -447,6 +451,8 @@ def test_scan_document_stacks_frames(monkeypatch):
         VideoCapture=FakeCapture,
         CAP_PROP_FRAME_WIDTH=0,
         CAP_PROP_FRAME_HEIGHT=0,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         imshow=lambda *a, **k: None,
         waitKey=lambda *a, **k: ord("s"),
         resize=lambda img, *a, **k: img,
@@ -488,7 +494,7 @@ def test_scan_document_quits_on_q(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             pass
 
         def set(self, *_):
@@ -507,6 +513,8 @@ def test_scan_document_quits_on_q(monkeypatch):
         VideoCapture=FakeCapture,
         CAP_PROP_FRAME_WIDTH=0,
         CAP_PROP_FRAME_HEIGHT=0,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         imshow=lambda *a, **k: None,
         waitKey=lambda *a, **k: ord("q"),
         resize=lambda img, *a, **k: img,
@@ -539,7 +547,7 @@ def test_scan_document_quits_on_window_close(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             pass
 
         def set(self, *_):
@@ -558,6 +566,8 @@ def test_scan_document_quits_on_window_close(monkeypatch):
         VideoCapture=FakeCapture,
         CAP_PROP_FRAME_WIDTH=0,
         CAP_PROP_FRAME_HEIGHT=0,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         imshow=lambda *a, **k: None,
         waitKey=lambda *a, **k: -1,
         resize=lambda img, *a, **k: img,


### PR DESCRIPTION
## Summary
- open camera in MJPG mode to ensure compressed stream
- update tests to handle fourcc params and MJPG setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4ba43aec483239fd2bcfe83b3f839