### PR TITLE
Open compressed video stream

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -171,8 +171,12 @@ def _open_capture(cam_index: int, cameras) -> cv2.VideoCapture:
         backend_const = getattr(cv2, const_name, None)
 
     if backend_const is not None:
-        return cv2.VideoCapture(cam_index, backend_const)
-    return cv2.VideoCapture(cam_index)
+        cap = cv2.VideoCapture(cam_index, backend_const)
+    else:
+        cap = cv2.VideoCapture(cam_index, getattr(cv2, "CAP_ANY", 0))
+
+    cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
+    return cap
 
 
 def check_tesseract_installation() -> None:  # pragma: no cover - thin wrapper

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -11,7 +11,7 @@ def setup_fake_cv2(monkeypatch):
     """Return the scanner module loaded with a stubbed cv2 module."""
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             self.index = index
 
         def isOpened(self):
@@ -31,6 +31,8 @@ def setup_fake_cv2(monkeypatch):
     fake_cv2 = SimpleNamespace(
         videoio_registry=registry,
         VideoCapture=FakeCapture,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         __version__="4.8.0",
     )
     # ``scanner`` imports ``cv2``, ``numpy`` and ``pytesseract`` at module import
@@ -103,6 +105,30 @@ def test_check_tesseract_configures_path(monkeypatch):
         scanner.pytesseract.pytesseract.tesseract_cmd
         == "C:/pf/Tesseract-OCR/tesseract.exe"
     )
+
+
+def test_open_capture_sets_fourcc(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    called = {}
+
+    class FakeCapture:
+        def __init__(self, index, backend):
+            called["init"] = (index, backend)
+            self.props = {}
+
+        def set(self, prop, value):
+            self.props[prop] = value
+
+    fake_cv2 = SimpleNamespace(
+        VideoCapture=FakeCapture,
+        CAP_PROP_FOURCC=1,
+        VideoWriter_fourcc=lambda *a: 1234,
+        CAP_ANY=0,
+    )
+    monkeypatch.setattr(scanner, "cv2", fake_cv2)
+
+    cap = scanner._open_capture(0, [])
+    assert cap.props[1] == 1234
 
 
 def test_no_gesture_flag(monkeypatch):
@@ -376,7 +402,7 @@ def test_scan_document_reuses_camera(monkeypatch):
         return 0
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             calls["open"] += 1
 
         def set(self, *_args):
@@ -395,6 +421,8 @@ def test_scan_document_reuses_camera(monkeypatch):
         VideoCapture=FakeCapture,
         CAP_PROP_FRAME_WIDTH=0,
         CAP_PROP_FRAME_HEIGHT=0,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         imshow=lambda *a, **k: None,
         waitKey=lambda *a, **k: ord("s"),
         resize=lambda img, *a, **k: img,
@@ -426,7 +454,7 @@ def test_scan_document_stacks_frames(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             self.count = 0
 
         def set(self, *_):
@@ -447,6 +475,8 @@ def test_scan_document_stacks_frames(monkeypatch):
         VideoCapture=FakeCapture,
         CAP_PROP_FRAME_WIDTH=0,
         CAP_PROP_FRAME_HEIGHT=0,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         imshow=lambda *a, **k: None,
         waitKey=lambda *a, **k: ord("s"),
         resize=lambda img, *a, **k: img,
@@ -488,7 +518,7 @@ def test_scan_document_quits_on_q(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             pass
 
         def set(self, *_):
@@ -507,6 +537,8 @@ def test_scan_document_quits_on_q(monkeypatch):
         VideoCapture=FakeCapture,
         CAP_PROP_FRAME_WIDTH=0,
         CAP_PROP_FRAME_HEIGHT=0,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         imshow=lambda *a, **k: None,
         waitKey=lambda *a, **k: ord("q"),
         resize=lambda img, *a, **k: img,
@@ -539,7 +571,7 @@ def test_scan_document_quits_on_window_close(monkeypatch):
     scanner = setup_fake_cv2(monkeypatch)
 
     class FakeCapture:
-        def __init__(self, index):
+        def __init__(self, index, *args):
             pass
 
         def set(self, *_):
@@ -558,6 +590,8 @@ def test_scan_document_quits_on_window_close(monkeypatch):
         VideoCapture=FakeCapture,
         CAP_PROP_FRAME_WIDTH=0,
         CAP_PROP_FRAME_HEIGHT=0,
+        CAP_PROP_FOURCC=0,
+        VideoWriter_fourcc=lambda *a: 0,
         imshow=lambda *a, **k: None,
         waitKey=lambda *a, **k: -1,
         resize=lambda img, *a, **k: img,


### PR DESCRIPTION
## Summary
- Open camera first then set MJPEG FOURCC so capture uses compressed stream
- Add regression test ensuring `_open_capture` configures MJPEG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ba43aec483239fd2bcfe83b3f839