### PR TITLE
Open camera stream in MJPEG mode

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -171,16 +171,12 @@ def _open_capture(cam_index: int, cameras) -> cv2.VideoCapture:
         backend_const = getattr(cv2, const_name, None)
 
     if backend_const is not None:
-        return cv2.VideoCapture(
-            cam_index,
-            backend_const,
-            [cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG")],
-        )
-    return cv2.VideoCapture(
-        cam_index,
-        getattr(cv2, "CAP_ANY", 0),
-        [cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG")],
-    )
+        cap = cv2.VideoCapture(cam_index, backend_const)
+    else:
+        cap = cv2.VideoCapture(cam_index, getattr(cv2, "CAP_ANY", 0))
+
+    cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*"MJPG"))
+    return cap
 
 
 def check_tesseract_installation() -> None:  # pragma: no cover - thin wrapper

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -14,6 +14,9 @@ def setup_fake_cv2(monkeypatch):
         def __init__(self, index, *args):
             self.index = index
 
+        def set(self, *_args, **_kwargs):
+            return True
+
         def isOpened(self):
             return False
 


### PR DESCRIPTION
## Summary
- Ensure camera capture negotiates MJPEG by setting the FOURCC after opening the stream
- Update camera tests to include a stubbed `set` method on `FakeCapture`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c6208eb08323a7ebae25d381a1d9