### PR TITLE
Add optional loop flag to rerun scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ camera parallel to the document for best results.
 - **Opens PDFs automatically** – each capture is written to a timestamped PDF.
 - **Overhead camera recommended** – works best with devices like the CZUR Lens
   and other cameras mounted perpendicular to the page.
+- **Optional looping** – add `--loop` to start a new scan after each PDF is saved.
 
 ## Requirements
 
@@ -42,7 +43,8 @@ python -m src.scanner
 ```
 
 Hold a document in view and show a V sign (or press `s`) to capture. Press `q`
-to quit.
+to quit. By default the application exits after saving the PDF. Pass `--loop`
+to automatically return to scanning for the next document.
 
 ### Preview window and performance
 

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -588,6 +588,11 @@ def build_parser() -> argparse.ArgumentParser:
             "actual scan"
         ),
     )
+    parser.add_argument(
+        "--loop",
+        action="store_true",
+        help="after saving a PDF, start a new scan instead of exiting",
+    )
     return parser
 
 
@@ -599,16 +604,27 @@ def main(argv: list[str] | None = None) -> None:
     if args.test_camera:
         test_camera()
     else:
-        while scan_document(
-            gesture_enabled=not args.no_gesture,
-            boost_contrast=not args.no_contrast,
-            output_dir=args.output_dir,
-            timeout=60,
-            stack_count=args.stack_count,
-            angle_threshold=args.angle_threshold,
-            fast_preview=args.fast_preview,
-        ):
-            pass
+        if args.loop:
+            while scan_document(
+                gesture_enabled=not args.no_gesture,
+                boost_contrast=not args.no_contrast,
+                output_dir=args.output_dir,
+                timeout=60,
+                stack_count=args.stack_count,
+                angle_threshold=args.angle_threshold,
+                fast_preview=args.fast_preview,
+            ):
+                pass
+        else:
+            scan_document(
+                gesture_enabled=not args.no_gesture,
+                boost_contrast=not args.no_contrast,
+                output_dir=args.output_dir,
+                timeout=60,
+                stack_count=args.stack_count,
+                angle_threshold=args.angle_threshold,
+                fast_preview=args.fast_preview,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -288,6 +288,36 @@ def test_fast_preview_flag(monkeypatch):
     assert called["fast_preview"] is True
 
 
+def test_runs_once_by_default(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    calls = {"count": 0}
+
+    def fake_scan(**kwargs):
+        calls["count"] += 1
+        return True
+
+    monkeypatch.setattr(scanner, "scan_document", fake_scan)
+    monkeypatch.setattr(sys, "argv", ["scanner"])
+    scanner.main()
+
+    assert calls["count"] == 1
+
+
+def test_loop_flag_runs_multiple_times(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    calls = {"count": 0}
+
+    def fake_scan(**kwargs):
+        calls["count"] += 1
+        return calls["count"] < 2
+
+    monkeypatch.setattr(scanner, "scan_document", fake_scan)
+    monkeypatch.setattr(sys, "argv", ["scanner", "--loop"])
+    scanner.main()
+
+    assert calls["count"] == 2
+
+
 def test_is_v_sign_sideways(monkeypatch):
     """The V gesture should be detected even when rotated 90 degrees."""
     scanner = setup_fake_cv2(monkeypatch)


### PR DESCRIPTION
## Summary
- add `--loop` flag to return to scanning after each capture
- update CLI docs in README
- test single-run default and loop behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4aea57c9c8323bfca6cab7ceb4aa4