### PR TITLE
Add Draw.io example diagram

### DIFF
--- a/examples/example.drawio
+++ b/examples/example.drawio
@@ -1,0 +1,13 @@
+<mxfile host="app.diagrams.net">
+  <diagram id="example" name="Page-1">
+    <mxGraphModel dx="827" dy="523" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="Hello, Draw.io" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="240" y="160" width="120" height="60" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
## Summary
- add a simple Draw.io diagram showcasing a labeled rounded rectangle

## Testing
- `xmllint examples/example.drawio`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9e4b0d1f88323a7e9365920bc9edd