### PR TITLE
Add automatic brightness normalization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ camera parallel to the document for best results.
 - **Orientation and OCR** – uses [Tesseract](https://github.com/tesseract-ocr/tesseract)
   to rotate pages upright and embed recognised text.
 - **Contrast boost and frame stacking** – improves legibility and reduces noise.
+- **Automatic brightness normalization** – stretches the brightest pixels to
+  white so light documents render crisply (disable with
+  `--no-brightness-correction`).
 - **Opens PDFs automatically** – each capture is written to a timestamped PDF.
 - **Overhead camera recommended** – works best with devices like the CZUR Lens
   and other cameras mounted perpendicular to the page.
@@ -43,6 +46,11 @@ python -m src.scanner
 
 Hold a document in view and show a V sign (or press `s`) to capture. Press `q`
 to quit.
+
+## Release channels
+
+The `stable` branch contains the most reliable builds. Check out this branch if
+you want the version with the fewest in-progress changes.
 
 ### Preview window and performance
 

--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -10,6 +10,30 @@ import pytesseract
 from .ocr_utils import check_tesseract_installation
 
 
+def normalize_brightness(image: np.ndarray) -> np.ndarray:
+    """Scale ``image`` so its brightest pixels reach full intensity."""
+
+    if image.size == 0:
+        return image
+
+    img = image.astype(np.float32)
+
+    if img.ndim == 2:
+        max_val = float(img.max())
+        if max_val <= 0:
+            return image
+        scale = 255.0 / max_val
+        adjusted = img * scale
+    else:
+        max_vals = img.reshape(-1, img.shape[-1]).max(axis=0)
+        scale = np.ones_like(max_vals)
+        nonzero = max_vals > 0
+        scale[nonzero] = 255.0 / max_vals[nonzero]
+        adjusted = img * scale.reshape(1, 1, -1)
+
+    return np.clip(adjusted, 0, 255).astype(np.uint8)
+
+
 def find_long_edges(
     image: np.ndarray,
     *,
@@ -84,4 +108,5 @@ __all__ = [
     "increase_contrast",
     "reduce_jpeg_artifacts",
     "correct_orientation",
+    "normalize_brightness",
 ]

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -26,6 +26,7 @@ from .image_utils import (
     increase_contrast,
     reduce_jpeg_artifacts,
     correct_orientation,
+    normalize_brightness,
 )
 from . import ocr_utils, __version__
 
@@ -260,6 +261,7 @@ def test_camera() -> None:
 def scan_document(
     gesture_enabled: bool = True,
     boost_contrast: bool = True,
+    auto_brightness: bool = True,
     output_dir: Path | str | None = None,
     timeout: float | None = None,
     stack_count: int = 10,
@@ -275,6 +277,10 @@ def scan_document(
         triggered only by pressing ``s``.
     boost_contrast:
         Apply a mild contrast stretch prior to OCR to improve legibility.
+    auto_brightness:
+        Normalize the captured frame so the brightest pixels map to full
+        intensity. This compensates for flat lighting when scanning light
+        documents.
     output_dir:
         Optional directory in which to save generated PDF files.
     timeout:
@@ -519,6 +525,8 @@ def scan_document(
         return False
 
     frame = correct_orientation(frame)
+    if auto_brightness:
+        frame = normalize_brightness(frame)
     if boost_contrast:
         frame = increase_contrast(frame)
     # Lightly denoise the frame to reduce visible JPEG artifacts before saving
@@ -561,7 +569,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--no-contrast",
         action="store_true",
-        help="skip the 25%% contrast boost before performing OCR",
+        help="skip the 25% contrast boost before performing OCR",
+    )
+    parser.add_argument(
+        "--no-brightness-correction",
+        action="store_true",
+        help="disable stretching the brightest pixels to full intensity",
     )
     parser.add_argument(
         "--output-dir",
@@ -606,6 +619,7 @@ def main(argv: list[str] | None = None) -> None:
         while scan_document(
             gesture_enabled=not args.no_gesture,
             boost_contrast=not args.no_contrast,
+            auto_brightness=not args.no_brightness_correction,
             output_dir=args.output_dir,
             timeout=60,
             stack_count=args.stack_count,

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -39,6 +39,39 @@ def test_reduce_jpeg_artifacts(monkeypatch):
     assert called["args"] == (10, 10, 7, 21)
 
 
+def test_normalize_brightness_scales_each_channel(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cv2", types.SimpleNamespace())
+    image_utils = importlib.import_module("src.image_utils")
+    importlib.reload(image_utils)
+
+    img = np.array(
+        [
+            [[100, 120, 200], [50, 60, 100]],
+        ],
+        dtype=np.uint8,
+    )
+
+    expected = np.clip(
+        img.astype(np.float32)
+        * np.array([255.0 / 100, 255.0 / 120, 255.0 / 200], dtype=np.float32),
+        0,
+        255,
+    ).astype(np.uint8)
+
+    result = image_utils.normalize_brightness(img)
+    assert np.array_equal(result, expected)
+
+
+def test_normalize_brightness_handles_dark_frames(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cv2", types.SimpleNamespace())
+    image_utils = importlib.import_module("src.image_utils")
+    importlib.reload(image_utils)
+
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    result = image_utils.normalize_brightness(img)
+    assert np.array_equal(result, img)
+
+
 def test_find_long_edges_detects_axes(monkeypatch):
     def fake_cvtColor(img, code):
         return img[:, :, 0]

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -118,6 +118,7 @@ def test_no_gesture_flag(monkeypatch):
         *,
         gesture_enabled,
         boost_contrast,
+        auto_brightness,
         output_dir,
         timeout=None,
         stack_count=10,
@@ -127,6 +128,7 @@ def test_no_gesture_flag(monkeypatch):
         called["args"] = (
             gesture_enabled,
             boost_contrast,
+            auto_brightness,
             output_dir,
             stack_count,
             angle_threshold,
@@ -136,7 +138,7 @@ def test_no_gesture_flag(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-gesture"])
     scanner.main()
 
-    assert called["args"] == (False, True, None, 10, 2)
+    assert called["args"] == (False, True, True, None, 10, 2)
 
 
 def test_no_contrast_flag(monkeypatch):
@@ -147,6 +149,7 @@ def test_no_contrast_flag(monkeypatch):
         *,
         gesture_enabled,
         boost_contrast,
+        auto_brightness,
         output_dir,
         timeout=None,
         stack_count=10,
@@ -156,6 +159,7 @@ def test_no_contrast_flag(monkeypatch):
         called["args"] = (
             gesture_enabled,
             boost_contrast,
+            auto_brightness,
             output_dir,
             stack_count,
             angle_threshold,
@@ -165,7 +169,31 @@ def test_no_contrast_flag(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["scanner", "--no-contrast"])
     scanner.main()
 
-    assert called["args"] == (True, False, None, 10, 2)
+    assert called["args"] == (True, False, True, None, 10, 2)
+
+
+def test_no_brightness_correction_flag(monkeypatch):
+    scanner = setup_fake_cv2(monkeypatch)
+    called = {}
+
+    def fake_scan(
+        *,
+        gesture_enabled,
+        boost_contrast,
+        auto_brightness,
+        output_dir,
+        timeout=None,
+        stack_count=10,
+        angle_threshold=2,
+        fast_preview=False,
+    ):
+        called["auto_brightness"] = auto_brightness
+
+    monkeypatch.setattr(scanner, "scan_document", fake_scan)
+    monkeypatch.setattr(sys, "argv", ["scanner", "--no-brightness-correction"])
+    scanner.main()
+
+    assert called["auto_brightness"] is False
 
 
 def test_output_dir_flag(monkeypatch, tmp_path):
@@ -176,6 +204,7 @@ def test_output_dir_flag(monkeypatch, tmp_path):
         *,
         gesture_enabled,
         boost_contrast,
+        auto_brightness,
         output_dir,
         timeout=None,
         stack_count=10,
@@ -185,6 +214,7 @@ def test_output_dir_flag(monkeypatch, tmp_path):
         called["args"] = (
             gesture_enabled,
             boost_contrast,
+            auto_brightness,
             output_dir,
             stack_count,
             angle_threshold,
@@ -198,7 +228,7 @@ def test_output_dir_flag(monkeypatch, tmp_path):
     )
     scanner.main()
 
-    assert called["args"] == (True, True, str(tmp_path), 10, 2)
+    assert called["args"] == (True, True, True, str(tmp_path), 10, 2)
 
 
 def test_angle_threshold_flag(monkeypatch):
@@ -209,6 +239,7 @@ def test_angle_threshold_flag(monkeypatch):
         *,
         gesture_enabled,
         boost_contrast,
+        auto_brightness,
         output_dir,
         timeout=None,
         stack_count=10,
@@ -232,6 +263,7 @@ def test_stack_count_flag(monkeypatch):
         *,
         gesture_enabled,
         boost_contrast,
+        auto_brightness,
         output_dir,
         timeout=None,
         stack_count=10,
@@ -255,6 +287,7 @@ def test_default_timeout(monkeypatch):
         *,
         gesture_enabled,
         boost_contrast,
+        auto_brightness,
         output_dir,
         timeout=None,
         stack_count=10,
@@ -278,6 +311,7 @@ def test_fast_preview_flag(monkeypatch):
         *,
         gesture_enabled,
         boost_contrast,
+        auto_brightness,
         output_dir,
         timeout=None,
         stack_count=10,
@@ -486,6 +520,7 @@ def test_scan_document_stacks_frames(monkeypatch):
     scanner.scan_document(
         gesture_enabled=False,
         boost_contrast=False,
+        auto_brightness=False,
         stack_count=3,
     )
 


### PR DESCRIPTION
## Summary
- add a brightness normalization helper that scales captures so the brightest pixels reach full intensity
- wire the correction into the scanner with a new `--no-brightness-correction` toggle and update the tests
- document the default correction behaviour and mention the new `stable` branch in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f183d349048323ae69602df644664a