### PR TITLE
Clip highlight levels when normalizing brightness

### DIFF
--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -10,8 +10,18 @@ import pytesseract
 from .ocr_utils import check_tesseract_installation
 
 
+WHITE_POINT_PERCENTILE = 85.0
+
+
 def normalize_brightness(image: np.ndarray) -> np.ndarray:
-    """Scale ``image`` so its brightest pixels reach full intensity."""
+    """Scale ``image`` so its near-white pixels reach full intensity.
+
+    Instead of stretching the dynamic range so that only the single
+    brightest pixel maps to ``255``, we treat the top ``WHITE_POINT_PERCENTILE``
+    of intensities as paper white.  This intentionally clips highlights so
+    that slightly dull regions of the page are pushed to pure white which
+    better matches the behaviour of a document scanner.
+    """
 
     if image.size == 0:
         return image
@@ -19,16 +29,17 @@ def normalize_brightness(image: np.ndarray) -> np.ndarray:
     img = image.astype(np.float32)
 
     if img.ndim == 2:
-        max_val = float(img.max())
-        if max_val <= 0:
+        white_point = float(np.percentile(img, WHITE_POINT_PERCENTILE))
+        if white_point <= 0:
             return image
-        scale = 255.0 / max_val
+        scale = 255.0 / white_point
         adjusted = img * scale
     else:
-        max_vals = img.reshape(-1, img.shape[-1]).max(axis=0)
-        scale = np.ones_like(max_vals)
-        nonzero = max_vals > 0
-        scale[nonzero] = 255.0 / max_vals[nonzero]
+        reshaped = img.reshape(-1, img.shape[-1])
+        white_points = np.percentile(reshaped, WHITE_POINT_PERCENTILE, axis=0)
+        scale = np.ones_like(white_points, dtype=np.float32)
+        nonzero = white_points > 0
+        scale[nonzero] = 255.0 / white_points[nonzero]
         adjusted = img * scale.reshape(1, 1, -1)
 
     return np.clip(adjusted, 0, 255).astype(np.uint8)

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -51,9 +51,13 @@ def test_normalize_brightness_scales_each_channel(monkeypatch):
         dtype=np.uint8,
     )
 
+    reshaped = img.reshape(-1, img.shape[-1])
+    white_points = np.percentile(
+        reshaped, image_utils.WHITE_POINT_PERCENTILE, axis=0
+    )
     expected = np.clip(
         img.astype(np.float32)
-        * np.array([255.0 / 100, 255.0 / 120, 255.0 / 200], dtype=np.float32),
+        * (255.0 / white_points).reshape(1, 1, -1),
         0,
         255,
     ).astype(np.uint8)
@@ -70,6 +74,24 @@ def test_normalize_brightness_handles_dark_frames(monkeypatch):
     img = np.zeros((2, 2, 3), dtype=np.uint8)
     result = image_utils.normalize_brightness(img)
     assert np.array_equal(result, img)
+
+
+def test_normalize_brightness_clips_highlights(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cv2", types.SimpleNamespace())
+    image_utils = importlib.import_module("src.image_utils")
+    importlib.reload(image_utils)
+
+    img = np.array(
+        [
+            [200, 220, 230, 240],
+            [10, 20, 30, 40],
+        ],
+        dtype=np.uint8,
+    )
+
+    result = image_utils.normalize_brightness(img)
+    assert result[0].max() == 255
+    assert 255 - result[0].min() <= 35
 
 
 def test_find_long_edges_detects_axes(monkeypatch):


### PR DESCRIPTION
## Summary
- treat the top 15% of pixel intensities as paper white during brightness normalization to clip highlights
- update image_utils tests to match the new percentile-based scaling and verify highlight compression

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f1876a9eb4832383a393da594ca46a